### PR TITLE
Update example to match current API

### DIFF
--- a/context/getting-started.md
+++ b/context/getting-started.md
@@ -31,7 +31,7 @@ This view tracks how many times it's been clicked.
 require 'live/view'
 
 class ClickCounter < Live::View
-	def initialize(id, **data)
+	def initialize(*)
 		super
 		
 		# Setup the initial state:
@@ -42,12 +42,12 @@ class ClickCounter < Live::View
 	def handle(event)
 		@data[:count] = Integer(@data[:count]) + 1
 		
-		replace!
+		update!
 	end
 	
 	def render(builder)
 		# Forward the `onclick` event to the server:
-		builder.tag :button, onclick: forward do
+		builder.tag :button, onclick: forward_event do
 			builder.text("I've been clicked #{@data[:count]} times!")
 		end
 	end

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -31,7 +31,7 @@ This view tracks how many times it's been clicked.
 require 'live/view'
 
 class ClickCounter < Live::View
-	def initialize(id, **data)
+	def initialize(*)
 		super
 		
 		# Setup the initial state:
@@ -42,12 +42,12 @@ class ClickCounter < Live::View
 	def handle(event)
 		@data[:count] = Integer(@data[:count]) + 1
 		
-		replace!
+		update!
 	end
 	
 	def render(builder)
 		# Forward the `onclick` event to the server:
-		builder.tag :button, onclick: forward do
+		builder.tag :button, onclick: forward_event do
 			builder.text("I've been clicked #{@data[:count]} times!")
 		end
 	end

--- a/lib/live/element.rb
+++ b/lib/live/element.rb
@@ -84,13 +84,13 @@ module Live
 			@page = nil
 		end
 		
-		# Handle a client event, typically as triggered by {#forward}.
+		# Handle a client event, typically as triggered by {#forward_event}.
 		# @parameter event [String] The type of the event.
 		def handle(event)
 		end
 		
 		# Enqueue a remote procedure call to the currently bound page.
-		# @parameter method [Symbol] The name of the remote functio to invoke.
+		# @parameter method [Symbol] The name of the remote function to invoke.
 		# @parameter arguments [Array]
 		def rpc(*arguments)
 			if @page


### PR DESCRIPTION
In the sample code:
- Remove the explicit parameter list from `ClickCounter#initialize` so that the example instantiation in the view works (`ClickCounter.new.to_html`)
- `replace!` is now `update!`
- `forward` is now `forward_event`

Also updated a reference to `#forward` in a method doc, and fixed a typo.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
